### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/src/lanyon/__init__.py
+++ b/src/lanyon/__init__.py
@@ -1,2 +1,2 @@
 __version__ = '7'
-__url__ = 'http://lanyon.readthedocs.org/'
+__url__ = 'https://lanyon.readthedocs.io/'


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
